### PR TITLE
fix: 팀명 생성 API request/response Swagger 적용

### DIFF
--- a/src/main/java/com/teamkrews/openAI/controller/TeamNameGeneratorController.java
+++ b/src/main/java/com/teamkrews/openAI/controller/TeamNameGeneratorController.java
@@ -1,8 +1,14 @@
 package com.teamkrews.openAI.controller;
 
+import com.teamkrews.openAI.model.request.SeedWords;
+import com.teamkrews.openAI.model.response.TeamNames;
 import com.teamkrews.openAI.service.TeamNameGeneratorService;
+import com.teamkrews.utill.ApiResponse;
+import com.teamkrews.workspace.model.Workspace;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
@@ -13,13 +19,20 @@ public class TeamNameGeneratorController {
 
     private final TeamNameGeneratorService teamNameGeneratorService;
 
-    @GetMapping("/generate/teamName")
-    public String generateTeamName(String seedWords) {
-        return teamNameGeneratorService.generateTeamName(seedWords);
+    @PostMapping("/generate/teamNames")
+    public ResponseEntity<TeamNames> generateTeamName(@RequestBody SeedWords request) {
+        TeamNames response = new TeamNames();
+
+        List<String> teamNames = teamNameGeneratorService.generateTeamName(request);
+        response.setTeamNames(teamNames);
+
+        return ResponseEntity.ok(response);
     }
 
     @PostMapping("/save/teamName/workspace/{workspaceUUID}")
-    public void saveSelectedTeamName(@PathVariable String workspaceUUID, @RequestBody String selectedTeamName) {
-        teamNameGeneratorService.saveTeamName(workspaceUUID, selectedTeamName);
+    public ResponseEntity<ApiResponse<Workspace>> saveSelectedTeamName(@PathVariable String workspaceUUID, @RequestBody String selectedTeamName) {
+        Workspace workspace = teamNameGeneratorService.saveTeamName(workspaceUUID, selectedTeamName);
+
+        return ResponseEntity.ok(ApiResponse.success(workspace));
     }
 }

--- a/src/main/java/com/teamkrews/openAI/controller/TeamNameGeneratorController.java
+++ b/src/main/java/com/teamkrews/openAI/controller/TeamNameGeneratorController.java
@@ -20,13 +20,13 @@ public class TeamNameGeneratorController {
     private final TeamNameGeneratorService teamNameGeneratorService;
 
     @PostMapping("/generate/teamNames")
-    public ResponseEntity<TeamNames> generateTeamName(@RequestBody SeedWords request) {
-        TeamNames response = new TeamNames();
+    public ResponseEntity<ApiResponse<TeamNames>> generateTeamName(@RequestBody SeedWords request) {
+        List<String> teamNamesList = teamNameGeneratorService.generateTeamName(request);
 
-        List<String> teamNames = teamNameGeneratorService.generateTeamName(request);
-        response.setTeamNames(teamNames);
+        TeamNames teamNames = new TeamNames();
+        teamNames.setTeamNames(teamNamesList);
 
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(ApiResponse.success(teamNames));
     }
 
     @PostMapping("/save/teamName/workspace/{workspaceUUID}")

--- a/src/main/java/com/teamkrews/openAI/model/request/SeedWords.java
+++ b/src/main/java/com/teamkrews/openAI/model/request/SeedWords.java
@@ -1,0 +1,11 @@
+package com.teamkrews.openAI.model.request;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SeedWords {
+    private List<String> seedWords;
+}

--- a/src/main/java/com/teamkrews/openAI/model/response/TeamNames.java
+++ b/src/main/java/com/teamkrews/openAI/model/response/TeamNames.java
@@ -1,0 +1,11 @@
+package com.teamkrews.openAI.model.response;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TeamNames {
+    private List<String> teamNames;
+}

--- a/src/main/java/com/teamkrews/openAI/service/TeamNameGeneratorService.java
+++ b/src/main/java/com/teamkrews/openAI/service/TeamNameGeneratorService.java
@@ -1,20 +1,21 @@
 package com.teamkrews.openAI.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamkrews.openAI.model.request.SeedWords;
 import com.teamkrews.openAI.model.response.TeamNames;
-import com.teamkrews.utill.ApiResponse;
 import com.teamkrews.workspace.model.Workspace;
 import com.teamkrews.workspace.repository.WorkspaceRepository;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
@@ -28,6 +29,7 @@ public class TeamNameGeneratorService {
 
     private final RestTemplate restTemplate;
     private final HttpHeaders httpHeaders;
+
     private final WorkspaceRepository workspaceRepository;
 
     // 팀명 4개 생성
@@ -37,19 +39,24 @@ public class TeamNameGeneratorService {
 
         String seedWordsStr = String.join(", ", seedWords);
 
+        /*
+        {
+            "teamNames": "{\n  \"id\": \"",\n  \"object\": \"chat.completion\",\n  \"created\": 1710689899,\n  \"model\": \"gpt-3.5-turbo-0125\",\n  \"choices\": [\n    {\n      \"index\": 0,\n      \"message\": {\n        \"role\": \"assistant\",\n        \"content\": \"1. 개발귀요미팀\\n2. 카카오ESG개발팀\\n3. 귀여운개발자들\\n4. ESG귀여운개발팀\"\n      },\n      \"logprobs\": null,\n      \"finish_reason\": \"stop\"\n    }\n  ],\n  \"usage\": {\n    \"prompt_tokens\": 72,\n    \"completion_tokens\": 53,\n    \"total_tokens\": 125\n  },\n  \"system_fingerprint\": \"fp_4f2ebda25a\"\n}\n"
+        }
+         */
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("model", "gpt-3.5-turbo");
         requestBody.put("temperature", 0.8);
-        requestBody.put("max_tokens", 64);
+        requestBody.put("max_tokens", 60);
         requestBody.put("top_p", 1);
         requestBody.put("messages", new Object[] {
                 new HashMap<String, String>() {{
                     put("role", "system");
-                    put("content", "시드 단어들을 기반으로 한글 팀 이름을 4개 생성해줘.");
+                    put("content", "우리 팀을 나타내는 키워드를 바탕으로 한글 팀 이름을 4개 추천해줘.");
                 }},
                 new HashMap<String, String>() {{
                     put("role", "user");
-                    put("content", String.format("시드 단어: %s.", seedWordsStr));
+                    put("content", String.format("키워드: %s.", seedWordsStr));
                 }}
         });
 
@@ -57,13 +64,47 @@ public class TeamNameGeneratorService {
 
         String generatedTeamNames = restTemplate.postForObject(url, entity, String.class);
 
-        List<String> teamNames = parse(generatedTeamNames);
-
-        return teamNames;
+        return parse(generatedTeamNames);
     }
 
+    /*
+    {
+        "success": true,
+        "code": "200",
+        "message": "Success",
+        "data": {
+            "teamNames": [
+                "1. 개발귀요미팀",
+                "2. 카카오ESG개발팀",
+                "3. 귀여운카카오ESG팀",
+                "4. 카카오ESG개발단체"
+            ]
+        }
+    }
+     */
     private List<String> parse(String generatedTeamNames) {
-        return Arrays.asList(generatedTeamNames.split(","));
+        List<String> teamNamesList = new ArrayList<>();
+
+        int contentStartIndex = generatedTeamNames.indexOf("\"content\": \"");
+        if (contentStartIndex != -1) {
+            contentStartIndex += "\"content\": \"".length();
+
+            int contentEndIndex = generatedTeamNames.indexOf("\"", contentStartIndex);
+            if (contentEndIndex != -1) {
+                String contentValue = generatedTeamNames.substring(contentStartIndex, contentEndIndex);
+                String[] teamNamesArray = contentValue.split("\\\\n");
+
+                for (String teamName : teamNamesArray) {
+                    teamNamesList.add(teamName.trim()); // 공백 제거
+                }
+            } else {
+                System.out.println("content 문자열의 마지막 따옴표를 찾을 수 없습니다.");
+            }
+        } else {
+            System.out.println("content 문자열을 찾을 수 없습니다.");
+        }
+
+        return teamNamesList;
     }
 
     // 선택한 팀명 저장


### PR DESCRIPTION
# 🔥 Task
## request 예시
`{
  "seedWords": ["개발", "카카오", "ESG", "귀여운"]
}`

- request는 seedWords List<String> 형식으로 받음

## response 예시
`{
    "success": true,
    "code": "200",
    "message": "Success",
    "data": {
        "teamNames": [
            "1. 개발귀요미팀",
            "2. 카카오ESG개발팀",
            "3. 귀여운카카오ESG팀",
            "4. 카카오ESG개발단체"
        ]
    }
}`