### PR TITLE
fix: 채팅방 생성 1:1 로직 수정 및 ChatRoom-Workspace-User DB 수정

### DIFF
--- a/src/main/java/com/teamkrews/User/model/User.java
+++ b/src/main/java/com/teamkrews/User/model/User.java
@@ -2,12 +2,9 @@ package com.teamkrews.User.model;
 
 import com.teamkrews.userworkspace.model.UserWorkspace;
 import jakarta.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.List;
 
 @Entity
 @Table(name = "user")

--- a/src/main/java/com/teamkrews/User/repository/UserRepository.java
+++ b/src/main/java/com/teamkrews/User/repository/UserRepository.java
@@ -8,7 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
-    public Optional<User> findById(final Long id);
-    public Optional<User> findByLoginId(final String loginId);
-
+    Optional<User> findByLoginId(final String loginId);
 }

--- a/src/main/java/com/teamkrews/User/service/UserService.java
+++ b/src/main/java/com/teamkrews/User/service/UserService.java
@@ -4,6 +4,9 @@ package com.teamkrews.User.service;
 
 import com.teamkrews.User.model.User;
 import com.teamkrews.User.repository.UserRepository;
+import com.teamkrews.chat.model.ChatRoom;
+import com.teamkrews.chat.repository.ChatRoomRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -16,16 +19,12 @@ import java.util.Optional;
 public class UserService {
     private final UserRepository userRepository;
 
-    public User getById(Long id){
-        Optional<User> byId = userRepository.findById(id);
+    public User getById(Long id) {
+        Optional<User> user = userRepository.findById(id);
 
-        if(byId.isEmpty()){
+        return user.orElseThrow(() -> {
             log.info("id = {} 인 사용자가 존재하지 않습니다", id);
-            throw new IllegalArgumentException();
-        }
-
-        return byId.get();
+            return new IllegalArgumentException("사용자를 찾을 수 없습니다.");
+        });
     }
-
-
 }

--- a/src/main/java/com/teamkrews/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/teamkrews/chat/controller/ChatRoomController.java
@@ -1,15 +1,15 @@
 package com.teamkrews.chat.controller;
 
 import com.teamkrews.chat.model.ChatRoom;
-import com.teamkrews.chat.repository.ChatRoomRepository;
+import com.teamkrews.chat.model.request.ChatRoomCreationRequest;
+import com.teamkrews.chat.model.response.ChatRoomResponse;
 import com.teamkrews.chat.service.ChatRoomService;
-import java.util.List;
+import com.teamkrews.utill.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,15 +20,21 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 public class ChatRoomController {
 
-    private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomService chatRoomService;
 
     // 1:1 채팅방 생성
-    @PostMapping("/create/chatRoom/{userId1}/{userId2}")
-    public ResponseEntity<ChatRoom> createChatRoom(@PathVariable Long userId1, @PathVariable Long userId2) {
+    // @RequestBody는 하나의 메서드에 여러 개일 수 없음!
+    // 따라서, 두 개의 Long 타입 파라미터을 받으려면 하나의 DTO 안에 넣어줘야함!
+    @PostMapping("/create/chatRoom")
+    public ResponseEntity<ApiResponse<ChatRoomResponse>> createChatRoom(@RequestBody ChatRoomCreationRequest request) {
         try {
-            ChatRoom chatRoom = chatRoomService.createChatRoomWithUser(userId1, userId2);
-            return ResponseEntity.ok(chatRoom);
+            ChatRoom chatRoom = chatRoomService.createChatRoomWithUser(request);
+
+            ChatRoomResponse chatRoomResponse = new ChatRoomResponse();
+            chatRoomResponse.setChatRoomId(chatRoom.getChatRoomId());
+            chatRoomResponse.setWorkspaceId(chatRoom.getWorkspace().getId());
+
+            return ResponseEntity.ok(ApiResponse.success(chatRoomResponse));
         } catch (RuntimeException e) {
             return ResponseEntity.badRequest().body(null);
         }
@@ -36,9 +42,5 @@ public class ChatRoomController {
 
     // 채팅방 목록 조회
     // 나중에 내가 먼저 보낸 채팅방 & 받은 채팅방으로 분리하기
-    @GetMapping("/")
-    public ResponseEntity<List<ChatRoom>> getAllChatRooms() {
-        List<ChatRoom> chatRooms = chatRoomRepository.findAll();
-        return ResponseEntity.ok(chatRooms);
-    }
+
 }

--- a/src/main/java/com/teamkrews/chat/model/ChatRoom.java
+++ b/src/main/java/com/teamkrews/chat/model/ChatRoom.java
@@ -1,11 +1,20 @@
 package com.teamkrews.chat.model;
 
+import com.teamkrews.User.model.User;
+import com.teamkrews.userworkspace.model.UserWorkspace;
+import com.teamkrews.workspace.model.Workspace;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
+import java.util.List;
+import java.util.Set;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -21,4 +30,10 @@ public class ChatRoom {
     @Column(name = "chat_room_id")
     private Long chatRoomId;
 
+    @OneToMany(mappedBy = "chatRoom")
+    private List<ChatRoomUser> chatRoomUsers;
+
+    @ManyToOne
+    @JoinColumn(name = "id")
+    private Workspace workspace;
 }

--- a/src/main/java/com/teamkrews/chat/model/ChatRoomUser.java
+++ b/src/main/java/com/teamkrews/chat/model/ChatRoomUser.java
@@ -21,7 +21,7 @@ public class ChatRoomUser {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "chat_room_user_id")
-    private Long chatRoomUserId;
+    private Long id;
 
     @ManyToOne
     @JoinColumn(name = "chat_room_id")
@@ -30,5 +30,4 @@ public class ChatRoomUser {
     @ManyToOne
     @JoinColumn(name = "user_id")
     private User user;
-
 }

--- a/src/main/java/com/teamkrews/chat/model/request/ChatRoomCreationRequest.java
+++ b/src/main/java/com/teamkrews/chat/model/request/ChatRoomCreationRequest.java
@@ -1,0 +1,12 @@
+package com.teamkrews.chat.model.request;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRoomCreationRequest {
+    private Long workspaceId;
+    private Long currentUserId;
+    private Long targetUserId;
+}

--- a/src/main/java/com/teamkrews/chat/model/response/ChatRoomResponse.java
+++ b/src/main/java/com/teamkrews/chat/model/response/ChatRoomResponse.java
@@ -1,0 +1,11 @@
+package com.teamkrews.chat.model.response;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ChatRoomResponse {
+    private Long chatRoomId;
+    private Long workspaceId;
+}

--- a/src/main/java/com/teamkrews/chat/service/ChatRoomService.java
+++ b/src/main/java/com/teamkrews/chat/service/ChatRoomService.java
@@ -3,47 +3,52 @@ package com.teamkrews.chat.service;
 import com.teamkrews.chat.model.ChatRoom;
 import com.teamkrews.chat.model.ChatRoomUser;
 import com.teamkrews.User.model.User;
+import com.teamkrews.chat.model.request.ChatRoomCreationRequest;
 import com.teamkrews.chat.repository.ChatRoomRepository;
 import com.teamkrews.chat.repository.ChatRoomUserRepository;
 import com.teamkrews.User.repository.UserRepository;
+import com.teamkrews.workspace.model.Workspace;
+import com.teamkrews.workspace.repository.WorkspaceRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 @Slf4j
 public class ChatRoomService {
 
+    private final UserRepository userRepository;
     private final ChatRoomRepository chatRoomRepository;
     private final ChatRoomUserRepository chatRoomUserRepository;
-    private final UserRepository userRepository;
+    private final WorkspaceRepository workspaceRepository;
 
     // 1:1 채팅방 생성
-    public ChatRoom createChatRoomWithUser(Long userId1, Long userId2) {
+    @Transactional
+    public ChatRoom createChatRoomWithUser(ChatRoomCreationRequest request) {
 
-        // 사용자 검색
-        User user1 = userRepository.findById(userId1)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId1));
-        User user2 = userRepository.findById(userId2)
-                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId2));
+        User currentUser = userRepository.findById(request.getCurrentUserId()).orElseThrow();
+        User targetUser = userRepository.findById(request.getTargetUserId()).orElseThrow();
+        Workspace workspace = workspaceRepository.findById(request.getWorkspaceId()).orElseThrow();
 
         // 채팅방 생성
         ChatRoom chatRoom = new ChatRoom();
-        chatRoom = chatRoomRepository.save(chatRoom);
+        chatRoom.setWorkspace(workspace);
+        chatRoomRepository.save(chatRoom);
 
-        // User - ChatRoom 관계 설정
-        ChatRoomUser chatRoomUser1 = new ChatRoomUser();
-        chatRoomUser1.setUser(user1);
-        chatRoomUser1.setChatRoom(chatRoom);
-        chatRoomUserRepository.save(chatRoomUser1);
-
-        ChatRoomUser chatRoomUser2 = new ChatRoomUser();
-        chatRoomUser2.setUser(user2);
-        chatRoomUser2.setChatRoom(chatRoom);
-        chatRoomUserRepository.save(chatRoomUser2);
+        // chatRoomUser - chatRoom / user 연결
+        connectUserToChatRoom(chatRoom, currentUser);
+        connectUserToChatRoom(chatRoom, targetUser);
 
         return chatRoom;
+    }
+
+    private void connectUserToChatRoom(ChatRoom chatRoom, User user) {
+        ChatRoomUser chatRoomUser = new ChatRoomUser();
+        chatRoomUser.setChatRoom(chatRoom);
+        chatRoomUser.setUser(user);
+        chatRoomUserRepository.save(chatRoomUser);
     }
 
     // 채팅방 조회

--- a/src/main/java/com/teamkrews/openAI/service/TeamNameGeneratorService.java
+++ b/src/main/java/com/teamkrews/openAI/service/TeamNameGeneratorService.java
@@ -109,7 +109,7 @@ public class TeamNameGeneratorService {
 
     // 선택한 팀명 저장
     public Workspace saveTeamName(String workspaceUUID, String selectedTeamName) {
-        Workspace workspace = workspaceRepository.findById(workspaceUUID)
+        Workspace workspace = workspaceRepository.findByWorkspaceUUID(workspaceUUID)
                 .orElseThrow(() -> new IllegalArgumentException("Workspace with uuid " + workspaceUUID + " not found"));
         workspace.setTeamName(selectedTeamName);
         workspaceRepository.save(workspace);

--- a/src/main/java/com/teamkrews/userworkspace/model/UserWorkspace.java
+++ b/src/main/java/com/teamkrews/userworkspace/model/UserWorkspace.java
@@ -12,6 +12,7 @@ import lombok.Setter;
 @Setter
 public class UserWorkspace {
     @Id
+    @Column(name = "user_workspace_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 

--- a/src/main/java/com/teamkrews/userworkspace/service/UserWorkspaceService.java
+++ b/src/main/java/com/teamkrews/userworkspace/service/UserWorkspaceService.java
@@ -1,6 +1,8 @@
 package com.teamkrews.userworkspace.service;
 
 import com.teamkrews.User.model.User;
+import com.teamkrews.User.repository.UserRepository;
+import com.teamkrews.chat.model.ChatRoom;
 import com.teamkrews.userworkspace.model.UserWorkspace;
 
 import com.teamkrews.userworkspace.model.UserWorkspaceCreateDto;
@@ -12,6 +14,7 @@ import com.teamkrews.workspace.model.Workspace;
 import com.teamkrews.workspace.model.response.WorkspaceInfoResponse;
 import com.teamkrews.workspace.service.WorkspaceService;
 import jakarta.transaction.Transactional;
+import java.util.ArrayList;
 import lombok.RequiredArgsConstructor;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;

--- a/src/main/java/com/teamkrews/workspace/model/Workspace.java
+++ b/src/main/java/com/teamkrews/workspace/model/Workspace.java
@@ -1,5 +1,7 @@
 package com.teamkrews.workspace.model;
 
+import com.teamkrews.chat.model.ChatRoom;
+import com.teamkrews.chat.model.ChatRoomUser;
 import com.teamkrews.userworkspace.model.UserWorkspace;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -20,5 +22,6 @@ public class Workspace {
     private List<UserWorkspace> userWorkspaces;
     private String profileImageUrl;
 
-    //채팅룸 추가 예정
+    @OneToMany(mappedBy = "workspace")
+    private List<ChatRoom> chatRooms;
 }

--- a/src/main/java/com/teamkrews/workspace/model/response/WorkspaceInfoResponse.java
+++ b/src/main/java/com/teamkrews/workspace/model/response/WorkspaceInfoResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 @Getter
 @Setter
 public class WorkspaceInfoResponse {
+    private Long workspaceId;
     private String workspaceUUID;
     private String teamName;
     private String profileImageUrl;

--- a/src/main/java/com/teamkrews/workspace/repository/WorkspaceRepository.java
+++ b/src/main/java/com/teamkrews/workspace/repository/WorkspaceRepository.java
@@ -7,6 +7,6 @@ import org.springframework.stereotype.Repository;
 import java.util.Optional;
 
 @Repository
-public interface WorkspaceRepository extends JpaRepository<Workspace, String> {
+public interface WorkspaceRepository extends JpaRepository<Workspace, Long> {
     Optional<Workspace> findByWorkspaceUUID(String workspaceUUID);
 }


### PR DESCRIPTION
# 🔥 Task
## 1. 1:1 채팅방 생성 parameter 수정
- request 바로 받아서 진행
- 현재 로그인 한 사용자의 id, 1:1 채팅방 대상 사용자의 id, 워크스페이스 id 받음 -> 향후 uuid로 변경 필요!

## 2. DB 변경 (User, ChatRoom, Workspace 위주)
- ChatRoom에 Workspace 추가 / Workspace에 ChatRoom 리스트 추가

## 3. 향후 추가 사항
- uuid 변환
- 인증된 사용자 로직 추가