### PR TITLE
[Fix] 유저 채팅방 리스트 조회

### DIFF
--- a/src/main/java/com/teamkrews/User/model/UserInfo.java
+++ b/src/main/java/com/teamkrews/User/model/UserInfo.java
@@ -8,12 +8,11 @@ import lombok.Setter;
 public class UserInfo {
     private String nickName;
     private String profileImageUrl;
-    private final String ANONYMOUS_PROFILE_IMAGE_URL =
-            "https://teamkrewsbucket.s3.ap-northeast-2.amazonaws.com/TeamKewsAnonymousProfileImage.png";
+
     public static UserInfo getAnonymousUserInfo(){
         UserInfo userInfo = new UserInfo();
         userInfo.setNickName("익명");
-        userInfo.setProfileImageUrl("ANONYMOUS_PROFILE_IMAGE_URL");
+        userInfo.setProfileImageUrl("https://teamkrewsbucket.s3.ap-northeast-2.amazonaws.com/TeamKewsAnonymousProfileImage.png");
         return userInfo;
     }
 }

--- a/src/main/java/com/teamkrews/chatRoomUser/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/teamkrews/chatRoomUser/repository/ChatRoomUserRepository.java
@@ -17,11 +17,12 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long> {
     List<ChatRoomUser> findByUserAndWorkspace(User user, Workspace workspace);
-
     Optional<ChatRoomUser> findByUserAndWorkspaceAndChatRoom(User user, Workspace workspace, ChatRoom chatRoom);
 
     List<ChatRoomUser> findByUserAndWorkspaceAndIsCreator(User user, Workspace workspace, int isCreator);
 
+    @Query("SELECT cru FROM ChatRoomUser cru LEFT JOIN FETCH cru.lastMessage lm WHERE cru.user = :user AND cru.workspace = :workspace AND cru.isCreator = :isCreator ORDER BY lm.createdAt ASC")
+    List<ChatRoomUser> findByUserAndWorkspaceAndIsCreatorOrderByLastMessage(@Param("user") User user, @Param("workspace") Workspace workspace, @Param("isCreator") int isCreator);
     List<ChatRoomUser> findByChatRoomAndIsCreator(ChatRoom chatRoom, int isCreator);
 
     List<ChatRoomUser> findAllByChatRoomAndNewState(ChatRoom chatRoom, Boolean newState);

--- a/src/main/java/com/teamkrews/chatRoomUser/service/ChatRoomUserService.java
+++ b/src/main/java/com/teamkrews/chatRoomUser/service/ChatRoomUserService.java
@@ -1,6 +1,7 @@
 package com.teamkrews.chatRoomUser.service;
 
 import com.teamkrews.User.model.User;
+import com.teamkrews.User.model.UserInfo;
 import com.teamkrews.User.model.UserInfos;
 import com.teamkrews.User.service.UserService;
 import com.teamkrews.chatRoomUser.model.ChatRoomUser;
@@ -16,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -58,6 +60,28 @@ public class ChatRoomUserService {
                     ).collect(Collectors.toList());
 
                     UserInfos otherUserInfos = userService.convertToInfos(otherUsers);
+
+                    return convertToResponse(chatRoomUser, otherUserInfos);
+                }
+
+        ).collect(Collectors.toList());
+
+        return new ChatRoomUserResponses(chatRoomUserResponseList);
+    }
+
+    public ChatRoomUserResponses convertToResponsesWithAnonymousUserInfo(List<ChatRoomUser> chatRoomUserList){
+        List<ChatRoomUserResponse> chatRoomUserResponseList = chatRoomUserList.stream().map(
+                (chatRoomUser) -> {
+                    List<ChatRoomUser> otherChatRoomUsers = chatRoomUserRepository.
+                            findByChatRoomAndNotUser(chatRoomUser.getChatRoom(), chatRoomUser.getUser());
+
+                    List<User> otherUsers = otherChatRoomUsers.stream().map((otherChatRoomUser) ->
+                            otherChatRoomUser.getUser()
+                    ).collect(Collectors.toList());
+                    ArrayList<UserInfo> userInfos = new ArrayList<>();
+                    userInfos.add(UserInfo.getAnonymousUserInfo());
+
+                    UserInfos otherUserInfos = new UserInfos(userInfos);
 
                     return convertToResponse(chatRoomUser, otherUserInfos);
                 }

--- a/src/main/java/com/teamkrews/chatroom/model/ChatRoomCreationDto.java
+++ b/src/main/java/com/teamkrews/chatroom/model/ChatRoomCreationDto.java
@@ -13,6 +13,8 @@ public class ChatRoomCreationDto {
         private List<Long> userIds;
         private Boolean isGroup = Boolean.FALSE;
 
+        public ChatRoomCreationDto(){
+        }
         public ChatRoomCreationDto(String workspaceUUID, Long creatorUserId, List<Long> userIds, Boolean isGroup) {
                 this.workspaceUUID = workspaceUUID;
                 this.creatorUserId = creatorUserId;

--- a/src/main/java/com/teamkrews/chatroom/service/ChatRoomService.java
+++ b/src/main/java/com/teamkrews/chatroom/service/ChatRoomService.java
@@ -91,7 +91,7 @@ public class ChatRoomService {
     // 내가 보낸 채팅방 조회
     public ChatRoomUserResponses getChatRoomsOfSent(User user, String workspaceUUID) {
         Workspace workspace = workspaceService.findByUUID(workspaceUUID);
-        List<ChatRoomUser> chatRoomUserSent = chatRoomUserRepository.findByUserAndWorkspaceAndIsCreator(user, workspace, 1);
+        List<ChatRoomUser> chatRoomUserSent = chatRoomUserRepository.findByUserAndWorkspaceAndIsCreatorOrderByLastMessage(user, workspace, 1);
 
         ChatRoomUserResponses chatRoomUserResponses = chatRoomUserService.convertToResponses(chatRoomUserSent);
         return chatRoomUserResponses;
@@ -100,9 +100,9 @@ public class ChatRoomService {
     // 내가 받은 채팅방 조회
     public ChatRoomUserResponses getChatRoomsOfReceived(User user, String workspaceUUID) {
         Workspace workspace = workspaceService.findByUUID(workspaceUUID);
-        List<ChatRoomUser> chatRoomUserReceived = chatRoomUserRepository.findByUserAndWorkspaceAndIsCreator(user, workspace, 0);
+        List<ChatRoomUser> chatRoomUserReceived = chatRoomUserRepository.findByUserAndWorkspaceAndIsCreatorOrderByLastMessage(user, workspace, 0);
 
-        ChatRoomUserResponses chatRoomUserResponses = chatRoomUserService.convertToResponses(chatRoomUserReceived);
+        ChatRoomUserResponses chatRoomUserResponses = chatRoomUserService.convertToResponsesWithAnonymousUserInfo(chatRoomUserReceived);
         return chatRoomUserResponses;
     }
 


### PR DESCRIPTION
# 🔥 Task
- 채팅방 리스트 조회시 초대 당한 채팅방일 경우, 사용자 정보 익명 처리
- 마지막 메시지를 받은 순서로 채팅방 리스트 정렬